### PR TITLE
feat: Add playerBuilder lambda to access and modify the building stage

### DIFF
--- a/compose-video/src/main/kotlin/io/sanghun/compose/video/VideoPlayer.kt
+++ b/compose-video/src/main/kotlin/io/sanghun/compose/video/VideoPlayer.kt
@@ -98,6 +98,7 @@ import kotlinx.coroutines.delay
  * @param enablePip Enable PIP (Picture-in-Picture).
  * @param enablePipWhenBackPressed With [enablePip] is `true`, set whether to enable PIP mode even when you press Back. Default is false.
  * @param handleAudioFocus Set whether to handle the video playback control automatically when it is playing in PIP mode and media is played in another app. Default is true.
+ * @param playerBuilder Return exoplayer builder. This instance allows you to customise the ExoPlayer while in the Building process. Used to add various components like other RenderFactories.
  * @param playerInstance Return exoplayer instance. This instance allows you to add [androidx.media3.exoplayer.analytics.AnalyticsListener] to receive various events from the player.
  */
 @SuppressLint("SourceLockedOrientationActivity", "UnsafeOptInUsageError")
@@ -122,6 +123,7 @@ fun VideoPlayer(
     defaultFullScreeen: Boolean = false,
     enablePipWhenBackPressed: Boolean = false,
     handleAudioFocus: Boolean = true,
+    playerBuilder: ExoPlayer.Builder.() -> ExoPlayer.Builder = { this },
     playerInstance: ExoPlayer.() -> Unit = {},
 ) {
     val context = LocalContext.current
@@ -151,6 +153,7 @@ fun VideoPlayer(
                     setMediaSourceFactory(DefaultMediaSourceFactory(cacheDataSourceFactory))
                 }
             }
+            .playerBuilder()
             .build()
             .also(playerInstance)
     }


### PR DESCRIPTION
Create a new param that returns the exoplayer builder. The instance allows to customise the ExoPlayer while in the Building process. Used to add various components like other RenderFactories.